### PR TITLE
Make the root arguments optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ import { SesModule } from '@nextm/nestjs-ses';
   imports: [
     SesModule.forRoot({
       SECRET: '<YOUR SECRET>',
-      AKI_KEY: '<YOUR AKI_KEY>',
+      API_KEY: '<YOUR API_KEY>',
       REGION: 'eu-west-1',
     }),
   ],

--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ import { SesModule } from '@nextm/nestjs-ses';
 @Module({
   imports: [
     SesModule.forRoot({
-      SECRET: '<YOUR SECRET>',
-      API_KEY: '<YOUR API_KEY>',
-      REGION: 'eu-west-1',
+      secret: '<YOUR SECRET>',
+      apiKey: '<YOUR API_KEY>',
+      region: 'eu-west-1',
     }),
   ],
   providers: [],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextnm/nestjs-ses",
-  "version": "0.0.5",
+  "version": "0.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextnm/nestjs-ses",
-  "version": "0.0.4",
+  "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextnm/nestjs-ses",
-  "version": "0.0.4",
+  "version": "0.1.0",
   "description": "NestJS provider for sending emails with ses",
   "author": "Nuno Carvalhão <nuno.carvalhao@gmail.com>",
   "license": "MIT",

--- a/src/nestjs-ses/configuration.ts
+++ b/src/nestjs-ses/configuration.ts
@@ -1,5 +1,5 @@
 export interface ConfigurationSes {
-  SECRET: string;
-  AKI_KEY: string;
-  REGION?: string;
+  secret: string;
+  apiKey: string;
+  region?: string;
 }

--- a/src/nestjs-ses/configuration.ts
+++ b/src/nestjs-ses/configuration.ts
@@ -1,5 +1,5 @@
 export interface ConfigurationSes {
-  secret: string;
-  apiKey: string;
+  secret?: string;
+  apiKey?: string;
   region?: string;
 }

--- a/src/nestjs-ses/services/relay/ses.service.spec.ts
+++ b/src/nestjs-ses/services/relay/ses.service.spec.ts
@@ -1,4 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { API_KEY, REGION, SECRET } from '../../tokens/tokens';
 import { SesService } from './ses.service';
 
 describe('SesService', () => {
@@ -6,7 +7,15 @@ describe('SesService', () => {
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [SesService],
+      providers: [
+        { provide: API_KEY, useValue: 'config.apiKey' },
+        {
+          provide: REGION,
+          useValue: 'config.region',
+        },
+        { provide: SECRET, useValue: 'config.secret' },
+        SesService,
+      ],
     }).compile();
 
     service = module.get<SesService>(SesService);

--- a/src/nestjs-ses/services/relay/ses.service.spec.ts
+++ b/src/nestjs-ses/services/relay/ses.service.spec.ts
@@ -5,23 +5,49 @@ import { SesService } from './ses.service';
 describe('SesService', () => {
   let service: SesService;
 
-  beforeEach(async () => {
-    const module: TestingModule = await Test.createTestingModule({
-      providers: [
-        { provide: API_KEY, useValue: 'config.apiKey' },
-        {
-          provide: REGION,
-          useValue: 'config.region',
-        },
-        { provide: SECRET, useValue: 'config.secret' },
-        SesService,
-      ],
-    }).compile();
+  describe('with all keys specified', () => {
+    beforeEach(async () => {
+      const module: TestingModule = await Test.createTestingModule({
+        providers: [
+          { provide: API_KEY, useValue: 'config.apiKey' },
+          {
+            provide: REGION,
+            useValue: 'config.region',
+          },
+          { provide: SECRET, useValue: 'config.secret' },
+          SesService,
+        ],
+      }).compile();
 
-    service = module.get<SesService>(SesService);
+      service = module.get<SesService>(SesService);
+    });
+
+    it('should be defined', () => {
+      expect(service).toBeDefined();
+    });
+
+    it('should have the apiKey', () => {
+      expect(service['apiKey']).toEqual('config.apiKey');
+    });
+    it('should have the region', () => {
+      expect(service['region']).toEqual('config.region');
+    });
+    it('should have the secret', () => {
+      expect(service['secret']).toEqual('config.secret');
+    });
   });
 
-  it('should be defined', () => {
-    expect(service).toBeDefined();
+  describe('with no keys specified', () => {
+    beforeEach(async () => {
+      const module: TestingModule = await Test.createTestingModule({
+        providers: [SesService],
+      }).compile();
+
+      service = module.get<SesService>(SesService);
+    });
+
+    it('should be defined', () => {
+      expect(service).toBeDefined();
+    });
   });
 });

--- a/src/nestjs-ses/services/relay/ses.service.ts
+++ b/src/nestjs-ses/services/relay/ses.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, Inject } from '@nestjs/common';
-import { AKI_KEY, REGION, SECRET } from '../../tokens/tokens';
+import { API_KEY, REGION, SECRET } from '../../tokens/tokens';
 import * as ses from 'node-ses';
 
 export interface SesEmailOptions {
@@ -17,7 +17,7 @@ export interface SesEmailOptions {
 export class SesService {
   private readonly ses;
   constructor(
-    @Inject(AKI_KEY) private readonly apiKey,
+    @Inject(API_KEY) private readonly apiKey,
     @Inject(REGION) private readonly region,
     @Inject(SECRET) private readonly secret,
   ) {
@@ -46,7 +46,6 @@ export class SesService {
     return new Promise((resolve, reject) => {
       this.ses.sendEmail(email, (err, data, res) => {
         if (err) {
-          console.error(err);
           return reject(err);
         }
         return resolve(res);

--- a/src/nestjs-ses/services/relay/ses.service.ts
+++ b/src/nestjs-ses/services/relay/ses.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Inject } from '@nestjs/common';
+import { Injectable, Inject, Optional } from '@nestjs/common';
 import { API_KEY, REGION, SECRET } from '../../tokens/tokens';
 import * as ses from 'node-ses';
 
@@ -17,9 +17,9 @@ export interface SesEmailOptions {
 export class SesService {
   private readonly ses;
   constructor(
-    @Inject(API_KEY) private readonly apiKey,
-    @Inject(REGION) private readonly region,
-    @Inject(SECRET) private readonly secret,
+    @Optional() @Inject(API_KEY) private readonly apiKey,
+    @Optional() @Inject(REGION) private readonly region,
+    @Optional() @Inject(SECRET) private readonly secret,
   ) {
     this.ses = ses.createClient({
       key: apiKey,

--- a/src/nestjs-ses/ses.module.ts
+++ b/src/nestjs-ses/ses.module.ts
@@ -1,6 +1,6 @@
 import { Module } from '@nestjs/common';
 import { ConfigurationSes } from './configuration';
-import { AKI_KEY, REGION, SECRET } from './tokens/tokens';
+import { API_KEY, REGION, SECRET } from './tokens/tokens';
 import { SesService } from './services/relay/ses.service';
 
 @Module({})
@@ -12,12 +12,12 @@ export class SesModule {
       //     ...controllers,
       //   ],
       providers: [
-        { provide: AKI_KEY, useValue: config.AKI_KEY },
+        { provide: API_KEY, useValue: config.apiKey },
         {
           provide: REGION,
-          useValue: config.REGION,
+          useValue: config.region,
         },
-        { provide: SECRET, useValue: config.SECRET },
+        { provide: SECRET, useValue: config.secret },
         SesService,
       ],
       exports: [SesService],

--- a/src/nestjs-ses/tokens/tokens.ts
+++ b/src/nestjs-ses/tokens/tokens.ts
@@ -1,3 +1,3 @@
-export const AKI_KEY = 'AKI_KEY';
-export const SECRET = 'SECRET';
-export const REGION = 'REGION';
+export const API_KEY = 'SES_API_KEY';
+export const SECRET = 'SES_SECRET';
+export const REGION = 'SES_REGION';


### PR DESCRIPTION
[node-ses `createClient`](https://www.npmjs.com/package/node-ses#createclient) will automatically load appropriate fallback values if none are supplied here. This makes autoconfiguration much easier.

This also merges #3 and #7 to avoid future merge conflicts and so I can use this branch for my app.
